### PR TITLE
Potential fix for code scanning alert no. 123: Resource exhaustion

### DIFF
--- a/tests/security/ensure-fingerprint-salt.production-cooldown-wait.spec.ts
+++ b/tests/security/ensure-fingerprint-salt.production-cooldown-wait.spec.ts
@@ -27,7 +27,11 @@ function sleep(ms: number) {
 
 describe('ensureFingerprintSalt production cooldown (wait realistic)', () => {
   it('waits the real cooldown period before retrying', async () => {
-    const concurrency = Number(process.env.STRESS_CONCURRENCY ?? 50);
+    const MAX_CONCURRENCY = 500;
+    let rawConcurrency = Number(process.env.STRESS_CONCURRENCY ?? 50);
+    if (!Number.isFinite(rawConcurrency) || rawConcurrency < 1) rawConcurrency = 1;
+    if (rawConcurrency > MAX_CONCURRENCY) rawConcurrency = MAX_CONCURRENCY;
+    const concurrency = rawConcurrency;
 
     let calls = 0;
     const failingEnsure = async () => {

--- a/tests/security/ensure-fingerprint-salt.production-stress.spec.ts
+++ b/tests/security/ensure-fingerprint-salt.production-stress.spec.ts
@@ -23,7 +23,10 @@ async function loadWithMockedEnsureCryptoAndProd(ensureCryptoImpl: () => Promise
 
 describe('ensureFingerprintSalt production cooldown stress', () => {
   it('concurrent failures set cooldown and block retries until cleared', async () => {
-    const concurrency = Number(process.env.STRESS_CONCURRENCY ?? 200);
+    const MAX_CONCURRENCY = 2000;
+    let concurrency = Number(process.env.STRESS_CONCURRENCY ?? 200);
+    if (isNaN(concurrency) || concurrency < 1) concurrency = 1;
+    if (concurrency > MAX_CONCURRENCY) concurrency = MAX_CONCURRENCY; // Avoid resource exhaustion
 
     let calls = 0;
     const failingEnsure = async () => {


### PR DESCRIPTION
Potential fix for [https://github.com/DavidOsipov/Security-kit/security/code-scanning/123](https://github.com/DavidOsipov/Security-kit/security/code-scanning/123)

To prevent resource exhaustion, add a check to restrict the maximum value of `concurrency` to a safe upper limit—e.g., 2000. If a user provides a value above the limit, either cap it at the maximum or throw an error, depending on desired behavior. This fix should be made on lines 26–27, directly after reading and parsing the environment variable. No third-party imports are required. Also, ensure that negative or NaN values are handled appropriately (such as defaulting to the minimum allowed value).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
